### PR TITLE
Fix verbatim r code chunk syntax

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -273,12 +273,12 @@ $A = (\pi * \lambda \times r^{4}) / \alpha $
 ***
 You can display 2 plots one beside each other. Add `out.width=c('50%', '50%'), fig.show='hold'` to your chunk header. Something like:
 
-```{r, eval=FALSE}
-``{r out.width=c('50%', '50%'), fig.show='hold'}
+````markdown
+```{r out.width=c('50%', '50%'), fig.show='hold'}`r ''`
 boxplot(1:10)
 plot(rnorm(10))
-`
 ```
+````
 
 ```{r out.width=c('50%', '50%'), fig.show='hold', echo=FALSE}
 boxplot(1:10)


### PR DESCRIPTION
Thanks for a wonderful repo.

I noticed this verbatim r code chunk isn't escaped in the standard way.

I have fixed using one of the old ways of doing this, e.g. detailed [here](https://bookdown.org/yihui/rmarkdown-cookbook/verbatim-code-chunks.html) and [here](https://rmarkdown.rstudio.com/articles_verbatim.html)

And you probably know that there is a new knitr (in knitr v1.37) verbatim chunk syntax (detailed [here](https://yihui.org/en/2022/01/knitr-news/))

`````
````{verbatim}
```{r}
1 + 1
```
````
`````

which you could use instead.

(I didn't re-render the html file - leave that to you.)
